### PR TITLE
Compiles under erlang 21

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ _*
 *~
 .erlang.cookie
 .DS_Store
-rebar.lock
 ebin
 log
 erl_crash.dump

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 sudo: false
 language: erlang
 otp_release:
-  - "19.1"
-  - "19.2"
+  - 21.0.2
+  - 20.3
+  - 19.3
 cache:
   directories:
   - $HOME/otp/19.1

--- a/rebar.config
+++ b/rebar.config
@@ -32,8 +32,8 @@
 ]}.
 
 {deps, [
-    {hut, "~> 1.2"},
-    {ssl_verify_fun, "~> 1.1"}
+    {hut, "~> 1.2.0"},
+    {ssl_verify_fun, "~> 1.1.4"}
 ]}.
 
 {profiles, [

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,0 +1,8 @@
+{"1.1.0",
+[{<<"hut">>,{pkg,<<"hut">>,<<"1.2.0">>},0},
+ {<<"ssl_verify_fun">>,{pkg,<<"ssl_verify_fun">>,<<"1.1.4">>},0}]}.
+[
+{pkg_hash,[
+ {<<"hut">>, <<"0089DF0FAA2827C605BBADA88153F24FFF5EA7A4BE32ECF0250A7FDC2719CAFB">>},
+ {<<"ssl_verify_fun">>, <<"F0EAFFF810D2041E93F915EF59899C923F4568F4585904D010387ED74988E77B">>}]}
+].

--- a/src/gen_rpc_acceptor.erl
+++ b/src/gen_rpc_acceptor.erl
@@ -12,6 +12,14 @@
 %%% Behaviour
 -behaviour(gen_statem).
 
+-ifdef(OTP_RELEASE). %% this implies 21 or higher
+-define(EXCEPTION(Class, Reason, Stacktrace), Class:Reason:Stacktrace).
+-define(GET_STACK(Stacktrace), Stacktrace).
+-else.
+-define(EXCEPTION(Class, Reason, _), Class:Reason).
+-define(GET_STACK(_), erlang:get_stacktrace()).
+-endif.
+
 %%% Include the HUT library
 -include_lib("hut/include/hut.hrl").
 %%% Include this library's name macro
@@ -267,7 +275,8 @@ call_middleman(M, F, A) ->
           catch
                throw:Term -> Term;
                exit:Reason -> {badrpc, {'EXIT', Reason}};
-               error:Reason -> {badrpc, {'EXIT', {Reason, erlang:get_stacktrace()}}}
+               ?EXCEPTION(error, Reason, Stacktrace) ->
+                   {badrpc, {'EXIT', {Reason, ?GET_STACK(Stacktrace)}}}
           end,
     erlang:exit({call_middleman_result, Res}),
     ok.


### PR DESCRIPTION
Erlang 21 was creating two errors, one for deprecation of
`:ssl.accept` and the other admonishing us to use the new method of
getting the stacktrace.